### PR TITLE
Modify direction of props

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -62,11 +62,11 @@ export class DelayInput extends React.PureComponent {
 
     return (
       <TextInput
-        {...props}
         onChangeText={this.onChangeText}
         onBlur={this.onBlur}
         value={value}
         ref={inputRef}
+        {...props}
       />
     );
   }


### PR DESCRIPTION
I want to use the 'onBlur' function, but I can't use it because it's below props. Therefore, I moved down so that the prop you specified would be used preferentially.